### PR TITLE
Prod fixes for Trip Invitations

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,7 +1,10 @@
 # API Configuration
+# Development (local backend)
 API_BASE_URL=http://localhost:3000/api
+# Production (Railway) - use this for release APK / Firebase distribution
+# API_BASE_URL=https://tripthread-backend-production.up.railway.app/api
 
-# Environment
+# Environment (development | production)
 ENVIRONMENT=development
 
 # Google Sign-In (same Web client ID as backend GOOGLE_CLIENT_ID; required for id token verification)

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:tripthread/services/share_service.dart';
 import 'package:tripthread/screens/trip/trip_map_screen.dart';
 import 'package:tripthread/services/api_service.dart';
 import 'package:tripthread/services/storage_service.dart';
+import 'package:tripthread/services/metadata_cache_service.dart';
 import 'package:tripthread/services/trip_service.dart';
 import 'package:tripthread/services/connectivity_service.dart';
 import 'package:tripthread/services/media_service.dart';
@@ -84,6 +85,16 @@ void main() async {
       rethrow;
     }
 
+    debugPrint('[main] Creating MetadataCacheService');
+    final metadataCacheService = MetadataCacheService();
+    try {
+      await metadataCacheService.init();
+      debugPrint('[main] MetadataCacheService initialized');
+    } catch (e) {
+      debugPrint('[main] MetadataCacheService initialization failed: $e');
+      rethrow;
+    }
+
     debugPrint('[main] Creating core services');
     final apiService = ApiService();
     final tripService = TripService();
@@ -99,6 +110,7 @@ void main() async {
       MultiProvider(
         providers: [
           Provider<StorageService>.value(value: storageService),
+          Provider<MetadataCacheService>.value(value: metadataCacheService),
           Provider<ApiService>.value(value: apiService),
           Provider<TripService>.value(value: tripService),
           Provider<MediaService>.value(value: mediaService),
@@ -133,11 +145,21 @@ void main() async {
           ChangeNotifierProvider<UserProvider>(
             create: (context) {
               debugPrint('[main] Creating UserProvider');
+              final apiService = context.read<ApiService>();
+              final metadataCache = context.read<MetadataCacheService>();
               final authProvider = context.read<AuthProvider>();
-              final userProvider = UserProvider(apiService: apiService);
-              // Listen to auth changes and clear UserProvider cache on logout
+              final userProvider = UserProvider(
+                apiService: apiService,
+                metadataCache: metadataCache,
+              );
               authProvider.addListener(() {
-                if (!authProvider.isAuthenticated) {
+                if (authProvider.isAuthenticated &&
+                    authProvider.currentUser != null) {
+                  userProvider.warmMetadataCacheIfNeeded(
+                    authProvider.currentUser!.id,
+                    currentUser: authProvider.currentUser,
+                  );
+                } else if (!authProvider.isAuthenticated) {
                   userProvider.clearCache();
                 }
               });

--- a/mobile/lib/models/unified_notification.dart
+++ b/mobile/lib/models/unified_notification.dart
@@ -135,6 +135,7 @@ class UnifiedNotificationItem {
   }
 
   bool get isFollowRequest => type == 'FOLLOW_REQUEST';
+  bool get isFollow => type == 'FOLLOW';
   bool get isLike => type == 'LIKE' || type == 'COMMENT_LIKE';
   bool get isCommentLike => type == 'COMMENT_LIKE';
   bool get isComment => type == 'COMMENT';

--- a/mobile/lib/providers/user_provider.dart
+++ b/mobile/lib/providers/user_provider.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:tripthread/models/follow_status.dart';
 import 'package:tripthread/models/unified_notification.dart';
 import 'package:tripthread/models/user.dart';
 import 'package:tripthread/services/api_service.dart';
+import 'package:tripthread/services/metadata_cache_service.dart';
 
 class FollowStatus {
   final bool isFollowing;
@@ -73,10 +76,15 @@ class DetailedFollowStatus {
 
 class UserProvider extends ChangeNotifier {
   final ApiService _apiService;
+  final MetadataCacheService? _metadataCache;
   String? _followRequestsError;
   String? isProcessingRequestId;
 
-  UserProvider({required ApiService apiService}) : _apiService = apiService;
+  UserProvider({
+    required ApiService apiService,
+    MetadataCacheService? metadataCache,
+  })  : _apiService = apiService,
+        _metadataCache = metadataCache;
 
   Future<User?> getCurrentUser() async {
     try {
@@ -98,6 +106,9 @@ class UserProvider extends ChangeNotifier {
   final Map<String, UserStats?> _statsCache = {};
   final Map<String, DetailedFollowStatus?> _detailedFollowStatusCache = {};
   final List<FollowRequestDto> _pendingFollowRequests = [];
+
+  /// Tracks which user's metadata we've already warmed this session (to avoid duplicate load+refresh).
+  String? _lastMetadataWarmedUserId;
 
   final List<Map<String, dynamic>> _discoverUsers = [];
   bool _isLoading = false;
@@ -139,10 +150,105 @@ class UserProvider extends ChangeNotifier {
   DetailedFollowStatus? getDetailedFollowStatus(String userId) =>
       _detailedFollowStatusCache[userId];
 
+  /// Removes cached profile data for [userId]. Call after follow/unfollow so the
+  /// next loadProfileData fetches fresh data (e.g. avatar, full profile).
+  void invalidateUserCache(String userId) {
+    _userCache.remove(userId);
+    _statsCache.remove(userId);
+    _detailedFollowStatusCache.remove(userId);
+    notifyListeners();
+  }
+
   // --- METHODS ---
   void clearError() {
     _error = null;
     notifyListeners();
+  }
+
+  /// Call once when app becomes authenticated (e.g. from auth listener).
+  /// Loads cache from disk then refreshes in background. Idempotent per [userId] per session.
+  /// Pass [currentUser] to seed in-memory cache so persisted metadata includes the user.
+  void warmMetadataCacheIfNeeded(String userId, {User? currentUser}) {
+    if (_lastMetadataWarmedUserId == userId) return;
+    _lastMetadataWarmedUserId = userId;
+    if (currentUser != null) {
+      _userCache[userId] = currentUser;
+    }
+    unawaited(_warmMetadataCacheIfNeededAsync(userId));
+  }
+
+  Future<void> _warmMetadataCacheIfNeededAsync(String userId) async {
+    await loadFromCache(userId);
+    await refreshMetadataInBackground(userId);
+  }
+
+  /// Loads cached metadata for [userId] from local storage and applies to state.
+  /// Use after login so profile/stats/requests show immediately; then call
+  /// [refreshMetadataInBackground] to fetch fresh data.
+  Future<void> loadFromCache(String userId) async {
+    final cache = _metadataCache;
+    if (cache == null) return;
+    try {
+      final data = await cache.loadUserMetadata(userId);
+      if (data.isEmpty) return;
+
+      final userJson = data['user'] as Map<String, dynamic>?;
+      if (userJson != null) {
+        try {
+          _userCache[userId] = User.fromJson(userJson);
+        } catch (_) {}
+      }
+      final statsJson = data['stats'] as Map<String, dynamic>?;
+      if (statsJson != null) {
+        try {
+          _statsCache[userId] = UserStats.fromJson(statsJson);
+        } catch (_) {}
+      }
+      final requestsList = data['pendingFollowRequests'];
+      if (requestsList is List && requestsList.isNotEmpty) {
+        try {
+          _pendingFollowRequests.clear();
+          for (final e in requestsList) {
+            if (e is Map<String, dynamic>) {
+              _pendingFollowRequests.add(FollowRequestDto.fromJson(e));
+            }
+          }
+        } catch (_) {}
+      }
+      notifyListeners();
+    } catch (e, st) {
+      debugPrint('[UserProvider] loadFromCache error: $e\n$st');
+    }
+  }
+
+  /// Fetches fresh stats and follow requests from API for [userId] (current user),
+  /// updates state and persists to cache. Call in background after [loadFromCache].
+  Future<void> refreshMetadataInBackground(String userId) async {
+    try {
+      final stats = await fetchUserStats(userId);
+      await loadPendingFollowRequests();
+      await _persistCurrentUserMetadata(userId);
+      if (stats != null) notifyListeners();
+    } catch (e, st) {
+      debugPrint('[UserProvider] refreshMetadataInBackground error: $e\n$st');
+    }
+  }
+
+  Future<void> _persistCurrentUserMetadata(String currentUserId) async {
+    final cache = _metadataCache;
+    if (cache == null) return;
+    try {
+      final user = _userCache[currentUserId];
+      final stats = _statsCache[currentUserId];
+      await cache.saveUserMetadata(
+        userId: currentUserId,
+        user: user,
+        stats: stats,
+        pendingFollowRequests: _pendingFollowRequests.isEmpty ? null : _pendingFollowRequests,
+      );
+    } catch (e, st) {
+      debugPrint('[UserProvider] _persistCurrentUserMetadata error: $e\n$st');
+    }
   }
 
   Future<void> loadProfileData(String userId, String currentUserId) async {
@@ -155,6 +261,9 @@ class UserProvider extends ChangeNotifier {
         fetchDetailedFollowStatus(userId),
         if (userId == currentUserId) loadPendingFollowRequests(),
       ]);
+      if (userId == currentUserId) {
+        await _persistCurrentUserMetadata(currentUserId);
+      }
     } catch (e) {
       _error =
           "Failed to load profile data:  [31m]"; // short for demo, replace as needed
@@ -254,12 +363,16 @@ class UserProvider extends ChangeNotifier {
           final status = getDetailedFollowStatus(userId);
           if (status?.isFollowing == true) {
             await fetchUserStats(currentUserId);
+            await fetchUserStats(userId);
           }
         }
         // Refresh pending follow requests to update notification count
         // This ensures the notification icon shows the new request
         await loadPendingFollowRequests();
         notifyListeners();
+        if (currentUserId != null) {
+          unawaited(_persistCurrentUserMetadata(currentUserId));
+        }
         return true;
       } else {
         _followRequestsError =
@@ -294,6 +407,9 @@ class UserProvider extends ChangeNotifier {
         }
         await fetchUserStats(userId);
         notifyListeners();
+        if (currentUserId != null) {
+          unawaited(_persistCurrentUserMetadata(currentUserId));
+        }
         return true;
       }
       _error = response.error ?? 'Failed to unfollow user';
@@ -325,6 +441,9 @@ class UserProvider extends ChangeNotifier {
           await fetchUserStats(currentUserId);
         }
         notifyListeners();
+        if (currentUserId != null) {
+          unawaited(_persistCurrentUserMetadata(currentUserId));
+        }
         return true;
       }
       _error = response.error ?? 'Failed to cancel request';
@@ -367,6 +486,7 @@ class UserProvider extends ChangeNotifier {
         await fetchUserStats(followerId);
 
         notifyListeners();
+        unawaited(_persistCurrentUserMetadata(followeeId));
         return true;
       }
       _followRequestsError =
@@ -406,6 +526,7 @@ class UserProvider extends ChangeNotifier {
         await fetchUserStats(followeeId);
 
         notifyListeners();
+        unawaited(_persistCurrentUserMetadata(followeeId));
         return true;
       }
       _followRequestsError =
@@ -547,6 +668,8 @@ class UserProvider extends ChangeNotifier {
     _unifiedNotifications.clear();
     _notificationsCursor = null;
     _unreadNotificationCount = 0;
+    _lastMetadataWarmedUserId = null;
+    unawaited(_metadataCache?.clearAll());
     notifyListeners();
   }
 

--- a/mobile/lib/screens/home/home_screen.dart
+++ b/mobile/lib/screens/home/home_screen.dart
@@ -1345,8 +1345,8 @@ class ProfileTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<AuthProvider>(
-      builder: (context, authProvider, child) {
+    return Consumer2<AuthProvider, TripProvider>(
+      builder: (context, authProvider, tripProvider, child) {
         final user = authProvider.currentUser;
 
         if (user == null) {
@@ -1364,13 +1364,51 @@ class ProfileTab extends StatelessWidget {
           });
         }
 
+        final pendingTripInvitations = tripProvider.pendingTripInvitations;
+
         return Scaffold(
           appBar: AppBar(
             centerTitle: false,
             title: const Text('Profile'),
             actions: [
+              // Trip Invitations (own profile tab)
+              Stack(
+                alignment: Alignment.center,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.mail_outline),
+                    tooltip: 'Trip Invitations',
+                    onPressed: () => context.push('/trip-invites'),
+                  ),
+                  if (pendingTripInvitations.isNotEmpty)
+                    Positioned(
+                      top: 8,
+                      right: 8,
+                      child: Container(
+                        padding: const EdgeInsets.all(2),
+                        decoration: BoxDecoration(
+                          color: Colors.red,
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                        constraints: const BoxConstraints(
+                          minWidth: 14,
+                          minHeight: 14,
+                        ),
+                        child: Text(
+                          '${pendingTripInvitations.length}',
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 8,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
               IconButton(
-                icon: const Icon(Icons.person),
+                icon: const Icon(Icons.person_add_outlined),
+                tooltip: 'Follow Requests',
                 onPressed: () async {
                   final currentUser = await userProvider.getCurrentUser();
                   if (currentUser != null) {

--- a/mobile/lib/screens/notifications/notifications_screen.dart
+++ b/mobile/lib/screens/notifications/notifications_screen.dart
@@ -5,8 +5,10 @@ import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:tripthread/models/unified_notification.dart';
+import 'package:tripthread/models/trip_join_request.dart';
 import 'package:tripthread/providers/user_provider.dart';
 import 'package:tripthread/providers/auth_provider.dart';
+import 'package:tripthread/providers/trip_provider.dart';
 import 'package:tripthread/services/api_service.dart';
 
 /// Time grouping for notifications
@@ -34,7 +36,10 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
       final userProvider = context.read<UserProvider>();
+      final tripProvider = context.read<TripProvider>();
       await userProvider.loadUnifiedNotifications();
+      if (!mounted) return;
+      await tripProvider.loadPendingTripInvitations();
       if (!mounted) return;
       await userProvider.loadUnreadNotificationCount();
 
@@ -42,7 +47,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
       // The delay lets users briefly see unread indicators before they clear.
       if (!mounted) return;
       if (userProvider.unreadNotificationCount > 0) {
-        Future.delayed(const Duration(milliseconds: 1500), () {
+        Future.delayed(const Duration(milliseconds: 3000), () {
           if (!mounted) return;
           _autoMarkAllAsRead(userProvider);
         });
@@ -83,7 +88,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
   List<UnifiedNotificationItem> _engagementNotifications(
     List<UnifiedNotificationItem> all,
   ) => all
-      .where((n) => n.isLike || n.isComment || n.isCommentReply || n.isTag)
+      .where((n) => n.isLike || n.isComment || n.isCommentReply || n.isTag || n.isFollow)
       .toList();
 
   NotificationTimeGroup _timeGroup(String createdAt) {
@@ -345,6 +350,12 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
       return;
     }
 
+    if (n.isFollow) {
+      context.push('/profile/${n.actor.id}');
+      unawaited(_markNotificationsAsRead([n], userProvider));
+      return;
+    }
+
     final navEntityType = n.navEntityType;
     final navEntityId = n.navEntityId;
     final threadEntryId = n.highlightThreadEntryId;
@@ -428,15 +439,27 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
             },
           ),
         ),
-        body: Consumer<UserProvider>(
-          builder: (context, userProvider, child) {
-            if (userProvider.isNotificationsLoading &&
-                userProvider.unifiedNotifications.isEmpty) {
+        body: Consumer2<UserProvider, TripProvider>(
+          builder: (context, userProvider, tripProvider, child) {
+            final followReqs = _followRequests(
+              userProvider.unifiedNotifications,
+            );
+            final engagement = _engagementNotifications(
+              userProvider.unifiedNotifications,
+            );
+            final tripInvites = tripProvider.pendingTripInvitations;
+
+            final hasAnyContent =
+                followReqs.isNotEmpty || engagement.isNotEmpty || tripInvites.isNotEmpty;
+            final stillLoading = userProvider.isNotificationsLoading ||
+                tripProvider.isTripInvitesLoading;
+            if (!hasAnyContent && stillLoading) {
               return const Center(child: CircularProgressIndicator());
             }
 
             if (userProvider.unifiedNotificationsError != null &&
-                userProvider.unifiedNotifications.isEmpty) {
+                userProvider.unifiedNotifications.isEmpty &&
+                tripInvites.isEmpty) {
               return Center(
                 child: Padding(
                   padding: const EdgeInsets.all(24),
@@ -466,14 +489,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
               );
             }
 
-            final followReqs = _followRequests(
-              userProvider.unifiedNotifications,
-            );
-            final engagement = _engagementNotifications(
-              userProvider.unifiedNotifications,
-            );
-
-            if (followReqs.isEmpty && engagement.isEmpty) {
+            if (followReqs.isEmpty && engagement.isEmpty && tripInvites.isEmpty) {
               return Center(
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
@@ -492,7 +508,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
                     ),
                     const SizedBox(height: 8),
                     Text(
-                      'Likes, comments and follow requests\nwill appear here',
+                      'Likes, comments, follow requests and trip invites\nwill appear here',
                       textAlign: TextAlign.center,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                         color: Theme.of(
@@ -508,11 +524,16 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
             return RefreshIndicator(
               onRefresh: () async {
                 await userProvider.loadUnifiedNotifications();
+                await tripProvider.loadPendingTripInvitations();
                 await userProvider.loadUnreadNotificationCount();
               },
               child: ListView(
                 padding: const EdgeInsets.only(bottom: 24),
                 children: [
+                  if (tripInvites.isNotEmpty) ...[
+                    _buildTripInvitesSummaryTile(context, tripInvites),
+                    const SizedBox(height: 16),
+                  ],
                   if (followReqs.isNotEmpty) ...[
                     _buildFollowRequestsSummaryTile(context, followReqs),
                     const SizedBox(height: 16),
@@ -552,6 +573,106 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
               ),
             );
           },
+        ),
+      ),
+    );
+  }
+
+  /// Trip invitations summary: "X invited you to trip Y" or "N trip invitations", taps to /trip-invites.
+  Widget _buildTripInvitesSummaryTile(
+    BuildContext context,
+    List<TripJoinRequest> tripInvites,
+  ) {
+    final count = tripInvites.length;
+    final first = tripInvites.first;
+    final senderName = first.sender?.name ?? first.sender?.username ?? 'Someone';
+    final tripTitle = first.trip?.title ?? 'a trip';
+    String label;
+    if (count == 1) {
+      label = '$senderName invited you to $tripTitle';
+    } else {
+      label = '$count trip invitations';
+    }
+
+    final avatarSize = 40.0;
+    final avatarUrl = first.sender?.avatarUrl;
+
+    return Material(
+      color: Theme.of(context).colorScheme.secondaryContainer.withValues(alpha: 0.3),
+      child: InkWell(
+        onTap: () => context.push('/trip-invites'),
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border(
+              left: BorderSide(
+                color: Theme.of(context).colorScheme.secondary,
+                width: 4,
+              ),
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                CircleAvatar(
+                  radius: avatarSize / 2,
+                  backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+                  backgroundImage: avatarUrl != null && avatarUrl.isNotEmpty
+                      ? CachedNetworkImageProvider(avatarUrl)
+                      : null,
+                  child: avatarUrl == null || avatarUrl.isEmpty
+                      ? Text(
+                          senderName.isNotEmpty ? senderName.substring(0, 1).toUpperCase() : '?',
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.onSecondaryContainer,
+                            fontSize: 18,
+                          ),
+                        )
+                      : null,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.card_travel,
+                            size: 18,
+                            color: Theme.of(context).colorScheme.secondary,
+                          ),
+                          const SizedBox(width: 6),
+                          Flexible(
+                            child: Text(
+                              label,
+                              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                                fontWeight: FontWeight.w500,
+                              ),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        'Tap to accept or reject',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(
+                  Icons.chevron_right,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ],
+            ),
+          ),
         ),
       ),
     );
@@ -970,6 +1091,10 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
       title = '$actorName requested to follow you';
       subtitle = null;
       icon = Icons.person_add;
+    } else if (n.isFollow) {
+      title = '$actorName started following you';
+      subtitle = null;
+      icon = Icons.person_add;
     } else if (n.isCommentLike) {
       title = '$actorName liked your comment';
       subtitle = n.contentPreview != null && n.contentPreview!.isNotEmpty
@@ -1015,6 +1140,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
     final timeAgo = _formatTimeAgo(n.createdAt);
     final isUnread =
         n.isFollowRequest ||
+        n.isFollow ||
         ((n.isLike || n.isComment || n.isCommentReply || n.isTag) &&
             (n.readAt == null || (n.readAt?.isEmpty ?? true)));
     final backgroundColor = isUnread

--- a/mobile/lib/screens/profile/profile_screen.dart
+++ b/mobile/lib/screens/profile/profile_screen.dart
@@ -130,8 +130,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
       ),
     );
 
-    // Force refresh of profile data to ensure UI is in sync
+    // Force refresh of profile data to ensure UI is in sync (avatar, stats, trips section)
     if (success) {
+      userProvider.invalidateUserCache(widget.userId);
       await userProvider.loadProfileData(
         widget.userId,
         authProvider.currentUser!.id,
@@ -250,40 +251,42 @@ class _ProfileScreenState extends State<ProfileScreen> {
     List<dynamic> pendingRequests,
     List<dynamic> pendingTripInvitations,
   ) {
+    // Show actions only on own profile (mail = trip invites, follow requests, settings).
     if (!isOwnProfile) {
       return [];
     }
 
-    return [
-      // Trip Invitations Button
-      Stack(
-        alignment: Alignment.center,
-        children: [
-          IconButton(
-            icon: const Icon(Icons.mail_outline),
-            tooltip: 'Trip Invitations',
-            onPressed: () => context.push('/trip-invites'),
-          ),
-          if (pendingTripInvitations.isNotEmpty)
-            Positioned(
-              top: 8,
-              right: 8,
-              child: Container(
-                padding: const EdgeInsets.all(2),
-                decoration: BoxDecoration(
-                  color: Colors.red,
-                  borderRadius: BorderRadius.circular(6),
-                ),
-                constraints: const BoxConstraints(minWidth: 14, minHeight: 14),
-                child: Text(
-                  '${pendingTripInvitations.length}',
-                  style: const TextStyle(color: Colors.white, fontSize: 8),
-                  textAlign: TextAlign.center,
-                ),
+    final tripInvitesAction = Stack(
+      alignment: Alignment.center,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.mail_outline),
+          tooltip: 'Trip Invitations',
+          onPressed: () => context.push('/trip-invites'),
+        ),
+        if (pendingTripInvitations.isNotEmpty)
+          Positioned(
+            top: 8,
+            right: 8,
+            child: Container(
+              padding: const EdgeInsets.all(2),
+              decoration: BoxDecoration(
+                color: Colors.red,
+                borderRadius: BorderRadius.circular(6),
+              ),
+              constraints: const BoxConstraints(minWidth: 14, minHeight: 14),
+              child: Text(
+                '${pendingTripInvitations.length}',
+                style: const TextStyle(color: Colors.white, fontSize: 8),
+                textAlign: TextAlign.center,
               ),
             ),
-        ],
-      ),
+          ),
+      ],
+    );
+
+    return [
+      tripInvitesAction,
       Stack(
         alignment: Alignment.center,
         children: [

--- a/mobile/lib/services/metadata_cache_service.dart
+++ b/mobile/lib/services/metadata_cache_service.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tripthread/models/follow_status.dart';
+import 'package:tripthread/models/user.dart';
+
+/// Persists current user metadata (profile, stats, follow requests) to local
+/// storage so the app can show data immediately on launch and avoid repeated
+/// DB fetches. Data is refreshed in the background after load.
+class MetadataCacheService {
+  static const String _keyPrefix = 'user_metadata_';
+  static const String _cachedAtKeySuffix = '_cached_at';
+
+  SharedPreferences? _prefs;
+
+  Future<void> init() async {
+    _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  SharedPreferences get _store {
+    final p = _prefs;
+    if (p == null) {
+      throw StateError(
+        'MetadataCacheService not initialized. Call init() first.',
+      );
+    }
+    return p;
+  }
+
+  String _key(String userId) => '$_keyPrefix$userId';
+  String _cachedAtKey(String userId) => '${_keyPrefix}$userId$_cachedAtKeySuffix';
+
+  /// Saves user metadata for [userId]. Pass null for any field to leave existing value unchanged (not used when saving full snapshot).
+  Future<void> saveUserMetadata({
+    required String userId,
+    User? user,
+    UserStats? stats,
+    List<FollowRequestDto>? pendingFollowRequests,
+  }) async {
+    try {
+      await init();
+      final existing = await loadUserMetadata(userId);
+      final userJson = user != null ? user.toJson() : existing['user'];
+      final statsJson = stats != null ? stats.toJson() : existing['stats'];
+      final requestsJson = pendingFollowRequests != null
+          ? pendingFollowRequests
+              .map((e) => _followRequestToJson(e))
+              .toList()
+          : existing['pendingFollowRequests'];
+
+      final map = <String, dynamic>{
+        if (userJson != null) 'user': userJson,
+        if (statsJson != null) 'stats': statsJson,
+        if (requestsJson != null) 'pendingFollowRequests': requestsJson,
+        'cachedAt': DateTime.now().toUtc().toIso8601String(),
+      };
+      final jsonStr = jsonEncode(map);
+      await _store.setString(_key(userId), jsonStr);
+      await _store.setString(
+        _cachedAtKey(userId),
+        map['cachedAt'] as String,
+      );
+    } catch (e, st) {
+      debugPrint('[MetadataCacheService] saveUserMetadata error: $e\n$st');
+    }
+  }
+
+  /// Loads cached metadata for [userId]. Returns map with keys user (Map?), stats (Map?), pendingFollowRequests (List?), cachedAt (String?).
+  Future<Map<String, dynamic>> loadUserMetadata(String userId) async {
+    try {
+      await init();
+      final jsonStr = _store.getString(_key(userId));
+      if (jsonStr == null || jsonStr.isEmpty) return {};
+      final map = jsonDecode(jsonStr) as Map<String, dynamic>?;
+      if (map == null) return {};
+      return map;
+    } catch (e, st) {
+      debugPrint('[MetadataCacheService] loadUserMetadata error: $e\n$st');
+      return {};
+    }
+  }
+
+  /// Returns cached-at time for [userId], or null if not cached.
+  Future<DateTime?> getCachedAt(String userId) async {
+    try {
+      await init();
+      final s = _store.getString(_cachedAtKey(userId));
+      if (s == null) return null;
+      return DateTime.tryParse(s);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static Map<String, dynamic> _followRequestToJson(FollowRequestDto e) {
+    final m = e.toJson();
+    m['follower'] = e.follower.toJson();
+    return m;
+  }
+
+  /// Clears cached metadata for [userId] (e.g. on logout).
+  Future<void> clearUserMetadata(String userId) async {
+    try {
+      await init();
+      await _store.remove(_key(userId));
+      await _store.remove(_cachedAtKey(userId));
+    } catch (e, st) {
+      debugPrint('[MetadataCacheService] clearUserMetadata error: $e\n$st');
+    }
+  }
+
+  /// Clears all metadata keys (use on logout).
+  Future<void> clearAll() async {
+    try {
+      await init();
+      final keys = _store.getKeys().where(
+            (k) => k.startsWith(_keyPrefix),
+          );
+      for (final k in keys) {
+        await _store.remove(k);
+      }
+    } catch (e, st) {
+      debugPrint('[MetadataCacheService] clearAll error: $e\n$st');
+    }
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: tripthread
 description: "TripThread - Travel Social Media Platform"
 publish_to: "none"
 
-version: 1.0.0+1
+version: 1.0.0+4
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
@@ -20,6 +20,9 @@ dependencies:
 
   # Secure Storage
   flutter_secure_storage: ^10.0.0
+
+  # Local cache for user metadata (non-sensitive)
+  shared_preferences: ^2.2.2
 
   # Navigation
   go_router: ^17.0.1

--- a/prisma/migrations/20260223000000_add_follow_notification_type/migration.sql
+++ b/prisma/migrations/20260223000000_add_follow_notification_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE 'FOLLOW';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ enum NotificationType {
   COMMENT
   COMMENT_REPLY
   TAG
+  FOLLOW
 }
 
 model Notification {

--- a/src/app/api/follow/[userId]/route.ts
+++ b/src/app/api/follow/[userId]/route.ts
@@ -4,6 +4,7 @@ import { AuthService } from "@/lib/auth";
 import { ApiResponse, FollowResponse, FollowStatusResponse } from "@/types/api";
 import { withAuth, withRateLimit, withLogging } from "@/lib/middleware";
 import { handlePrismaUniqueError } from "@/lib/prismaErrors";
+import { createNotification } from "@/lib/services/notification";
 
 export async function GET(
   request: NextRequest,
@@ -247,6 +248,13 @@ export async function POST(
             );
           }
           if (result.code === "FOLLOW_CREATED" && result.follow) {
+            createNotification({
+              type: "FOLLOW",
+              actorId: followerId,
+              recipientId: followeeId,
+            }).catch((err) =>
+              console.error("[Notification] Failed to create FOLLOW notification:", err)
+            );
             return NextResponse.json(
               {
                 success: true,

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,34 +1,68 @@
 import { PrismaClient } from "@prisma/client";
 
 const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined;
+  prisma: ReturnType<typeof createPrismaWithRetry> | undefined;
 };
 
-const prismaClient =
-  globalForPrisma.prisma ??
-  new PrismaClient({
+function isConnectionClosedError(e: unknown): boolean {
+  if (!e || typeof e !== "object") return false;
+  const msg = (e as Error).message ?? "";
+  const code = (e as { code?: string }).code ?? "";
+  return (
+    msg.includes("Closed") ||
+    msg.includes("connection closed") ||
+    code === "P1001" ||
+    code === "P1017"
+  );
+}
+
+function createPrismaWithRetry() {
+  const base = new PrismaClient({
     log:
       process.env.NODE_ENV === "development"
         ? ["query", "error", "warn"]
         : ["error"],
   });
 
+  const extended = base.$extends({
+    name: "reconnect-on-closed",
+    query: {
+      $allOperations({ operation, model, args, query }) {
+        return query(args).catch(async (e: unknown) => {
+          if (!isConnectionClosedError(e)) throw e;
+          try {
+            await base.$connect();
+            return query(args);
+          } catch (retryErr) {
+            throw retryErr;
+          }
+        });
+      },
+    },
+  });
+
+  return { base, client: extended };
+}
+
+let created = globalForPrisma.prisma;
+if (!created) {
+  created = createPrismaWithRetry();
+  if (process.env.NODE_ENV !== "production") {
+    globalForPrisma.prisma = created;
+  }
+}
+const prismaBase = created.base;
+const prismaClient = created.client;
+
 // Connection will be tested by startup logger
-// Don't exit on error here - let the startup logger handle it
-prismaClient
+prismaBase
   .$connect()
-  .then(() => {
-    // Connection successful - startup logger will log this
-  })
+  .then(() => {})
   .catch((e) => {
-    // Error will be caught and logged by startup logger
     console.error(
       "Database connection error (will be logged by startup logger):",
       e
     );
   });
-
-if (process.env.NODE_ENV !== "production")
-  globalForPrisma.prisma = prismaClient;
 
 export const prisma = prismaClient;

--- a/src/lib/services/notification.ts
+++ b/src/lib/services/notification.ts
@@ -2,7 +2,7 @@ import type { EntityType, NotificationType, Prisma } from '@prisma/client'
 import { prisma } from '../prisma'
 
 export type CreateNotificationParams = {
-  type: 'LIKE' | 'COMMENT_LIKE' | 'COMMENT' | 'COMMENT_REPLY' | 'TAG'
+  type: 'LIKE' | 'COMMENT_LIKE' | 'COMMENT' | 'COMMENT_REPLY' | 'TAG' | 'FOLLOW'
   actorId: string
   recipientId: string
   entityType?: EntityType
@@ -11,7 +11,7 @@ export type CreateNotificationParams = {
 }
 
 export type UnifiedNotificationItem = {
-  type: 'FOLLOW_REQUEST' | 'LIKE' | 'COMMENT_LIKE' | 'COMMENT' | 'COMMENT_REPLY' | 'TAG'
+  type: 'FOLLOW_REQUEST' | 'FOLLOW' | 'LIKE' | 'COMMENT_LIKE' | 'COMMENT' | 'COMMENT_REPLY' | 'TAG'
   id: string
   createdAt: string
   readAt?: string | null
@@ -245,7 +245,7 @@ export async function getMergedNotifications(
     (n: Notif) => {
       const meta = n.metadata && typeof n.metadata === 'object' ? (n.metadata as Record<string, unknown>) : null
       return {
-        type: n.type as 'LIKE' | 'COMMENT_LIKE' | 'COMMENT' | 'COMMENT_REPLY' | 'TAG',
+        type: n.type as 'LIKE' | 'COMMENT_LIKE' | 'COMMENT' | 'COMMENT_REPLY' | 'TAG' | 'FOLLOW',
         id: n.id,
         createdAt: n.createdAt.toISOString(),
         readAt: n.readAt?.toISOString() ?? null,


### PR DESCRIPTION
trip invites in notifications, FOLLOW notifications, profile mail icon and cache refresh

- Notifications: show trip invitations section and load trip invites on open; add FOLLOW notification tile and tap-to-profile
- Profile: invalidate user cache after follow/unfollow so avatar and stats refresh; show mail/follow/settings only on own profile
- Profile tab: add Trip Invitations (mail) icon and Follow Requests icon so own profile has quick access to trip invites
## Summary

This PR adds trip invitation visibility on the notifications screen, proper display and navigation for "X started following you" (FOLLOW) notifications, and fixes the Trip Invitations (mail) icon so it appears on the user’s own profile (Profile tab) and not on other users’ profiles. It also ensures profile avatar and stats refresh correctly after follow/unfollow by invalidating the viewed user’s cache before refetching.

## Changes Made

* **Notifications screen**
  * Load `TripProvider.loadPendingTripInvitations()` when opening the screen so trip invites are up to date.
  * Add a "Trip invitations" section at the top (summary tile: "X invited you to trip Y" or "N trip invitations") that navigates to `/trip-invites` on tap so the bell badge count and list match and users can accept/reject.
  * Add UI and tap handling for FOLLOW notifications: show "X started following you" and tap navigates to actor’s profile; include FOLLOW in unread state for the left border/mark-as-read.
* **Profile (own vs other)**
  * **Profile tab (bottom nav):** Add Trip Invitations (mail) icon and use Follow Requests (person_add) icon with badge; keep Settings and Logout. Uses `Consumer2<AuthProvider, TripProvider>` for the trip-invites badge.
  * **ProfileScreen (`/profile/:userId`):** Show app bar actions (mail, follow requests, settings) only when viewing **own** profile; show no actions when viewing another user’s profile so the mail icon no longer appears on others’ profiles.
* **Profile data after follow**
  * **UserProvider:** Add `invalidateUserCache(userId)` to clear cached user, stats, and follow status for a user.
  * **ProfileScreen:** After a successful follow/unfollow, call `invalidateUserCache(widget.userId)` then `loadProfileData(...)` so the viewed profile (avatar and stats) refreshes immediately.

## How to Test

1. **Trip invites in notifications**
   * Have another user send you a trip invite. Open Notifications (bell). You should see a "Trip invitations" block at the top; tap it and confirm you land on Trip Invitations and can accept/reject.
   * Pull to refresh on the notifications screen and confirm trip invites reload.
2. **FOLLOW notifications**
   * With a public account, have someone follow you. Open Notifications and confirm a "X started following you" tile; tap it and confirm you go to that user’s profile.
3. **Mail icon on own profile only**
   * Open the Profile tab (bottom nav). Confirm the mail (Trip Invitations) icon and Follow Requests icon appear in the app bar; tap mail and confirm you reach Trip Invitations.
   * From Discover, open another user’s profile. Confirm there is no mail icon (and no other actions) in the app bar.
4. **Profile refresh after follow**
   * Open another user’s profile (that you don’t follow). Follow them. Confirm their avatar and follower/following counts update without leaving the screen (and, if applicable, that stats were not stale from before follow).

## Related Issues/Tickets

* Addresses: notification badge showing count but trip invites not listed; FOLLOW notifications not shown/tappable; mail icon missing on own profile and showing on others’; profile DP/stats not updating after follow.

## Screenshots/GIFs (if applicable)

[ Optional: add screenshots of the notifications screen with trip invites section, FOLLOW tile, Profile tab with mail icon, and other profile with no mail icon. ]

## Notes for Reviewers

* Backend already creates FOLLOW notifications on public follow and returns them in `getMergedNotifications`; this PR only adds mobile display and navigation.
* Trip invitations still come from `GET /users/me/trip-invites`; the notifications screen now loads them and shows a summary section that links to the existing Trip Invitations screen.
* Realtime follow/follower stats were already updated in the provider after follow/unfollow/accept; the new `invalidateUserCache` + refetch ensures the **viewed** user’s profile (e.g. avatar) is refetched so the UI is not stale.

---

**Before Submitting:**

*   [x] Code follows project coding standards.
*   [ ] Unit tests have been added/updated.
*   [x] Manual testing has been performed.
*   [ ] Documentation has been updated (if applicable).
