### PR TITLE
Build fixes

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -66,3 +66,8 @@ prismaBase
   });
 
 export const prisma = prismaClient;
+
+/** Type of the client passed to prisma.$transaction(async (tx) => ...) — use for services that accept an optional tx. */
+export type PrismaTransactionClient = Parameters<
+  Parameters<typeof prismaClient.$transaction>[0]
+>[0];

--- a/src/lib/services/engagement-utils.ts
+++ b/src/lib/services/engagement-utils.ts
@@ -1,5 +1,5 @@
-import { EntityType, Prisma } from "@prisma/client";
-import { prisma } from "../prisma";
+import { EntityType } from "@prisma/client";
+import { prisma, type PrismaTransactionClient } from "../prisma";
 import { redis, memoryCache } from "../redis";
 
 // CONSTANTS
@@ -141,7 +141,7 @@ export async function incrementEntityCount(
   entityType: EntityType,
   entityId: string,
   countType: CountType,
-  tx: Prisma.TransactionClient
+  tx: PrismaTransactionClient
 ): Promise<void> {
   switch (entityType) {
     case "TRIP_FINAL_POST":
@@ -179,7 +179,7 @@ export async function decrementEntityCount(
   entityType: EntityType,
   entityId: string,
   countType: CountType,
-  tx: Prisma.TransactionClient
+  tx: PrismaTransactionClient
 ): Promise<void> {
   switch (entityType) {
     case "TRIP_FINAL_POST": {

--- a/src/lib/services/tripFinalizer.ts
+++ b/src/lib/services/tripFinalizer.ts
@@ -1,11 +1,10 @@
-import { prisma } from "@/lib/prisma";
+import { prisma, type PrismaTransactionClient } from "@/lib/prisma";
 import {
   GenerationStatus,
   MediaProcessingStatus,
   MediaType,
   Trip,
   TripFinalPost,
-  PrismaClient,
 } from "@prisma/client";
 import {
   AuthorizationError,
@@ -31,20 +30,12 @@ export class TripFinalizerService {
    * Generate final post for a trip. Can work with or without a transaction client.
    * @param tripId - The trip ID
    * @param userId - The user ID (optional for scheduler/system operations)
-   * @param tx - Optional transaction client for atomic operations
+   * @param tx - Optional transaction client for atomic operations (same type as prisma for extended client compatibility)
    */
   static async generateFinalPost(
     tripId: string,
     userId?: string,
-    tx?: Omit<
-      PrismaClient,
-      | "$connect"
-      | "$disconnect"
-      | "$on"
-      | "$transaction"
-      | "$use"
-      | "$extends"
-    >
+    tx?: PrismaTransactionClient | typeof prisma
   ) {
     const db = tx || prisma;
 


### PR DESCRIPTION
Prisma extended client type compatibility with transaction callbacks

- Export PrismaTransactionClient from prisma.ts for tx type in $transaction callbacks
- tripFinalizer: generateFinalPost accepts PrismaTransactionClient | typeof prisma
- engagement-utils: incrementEntityCount/decrementEntityCount use PrismaTransactionClient Fixes npm run build after Prisma reconnect-on-closed extension.

## Summary

[ Briefly explain the purpose of this PR and the problem it solves. (1-2 sentences) ]

## Changes Made

[ List the key changes introduced in this PR. Be specific but concise. ]

*   [ Change 1 ]
*   [ Change 2 ]
*   [ Change 3 ]
*   ...

## How to Test

[ Provide clear steps for reviewers to test the changes. ]

1.  [ Step 1 ]
2.  [ Step 2 ]
3.  [ Step 3 ]
4.  ...

## Related Issues/Tickets

[ Link any relevant issues or tickets. ]

*   Closes #[Issue Number]
*   Addresses [Ticket ID]

## Screenshots/GIFs (if applicable)[ Include screenshots or GIFs to demonstrate UI changes. ]

## Notes for Reviewers

[ Add any specific points you want reviewers to focus on or any context they might need. ]

---

**Before Submitting:**

*   [ ] Code follows project coding standards.
*   [ ] Unit tests have been added/updated.
*   [ ] Manual testing has been performed.
*   [ ] Documentation has been updated (if applicable).
